### PR TITLE
Aggiunti indici tabelle e immagini

### DIFF
--- a/templates/documento.typ
+++ b/templates/documento.typ
@@ -27,6 +27,8 @@
   state: none,
   intern: true,
   show_outline: true,
+  show_images_list: false,
+  show_tables_list: false,
   outline_depth: none,
   changelog: none,
   paper: "a4",
@@ -141,6 +143,22 @@
     show outline.entry.where(level: 1): strong
     outline(depth: outline_depth, indent: 1em)
     pagebreak()
+  }
+
+  if show_images_list == true {
+    outline(
+      title: "Lista della immagini",
+      target: figure.where(kind: image),
+    )
+  }
+  if show_tables_list == true {
+    outline(
+      title: "Lista delle tabelle",
+      target: figure.where(kind: table),
+    )
+  }
+  if show_images_list == true or show_tables_list == true {
+    pb()
   }
   
   set text(hyphenate: true)


### PR DESCRIPTION
close #137
Per attivare gli indici di tabelle e immagini bisognerà impostare i parametri `show_images_list` e `show_tables_list` a true nella funzione conf del documento
Inoltre, per far sì che una tabella appaia nella lista, è necessario che venga racchiusa in un tag `figure`, che abbia obbligatoriamente una `caption` (vale anche se vuota) (vale anche per le tabelle nel template, ad esempio `decisioni`)
`figure(table(...), caption: [Insert caption])`